### PR TITLE
Don’t modify the options param that is passed in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# master
+
+* fix options handling for `simple_delay_spread`
+
 # 0.2.0
 
 * `simple_delay_spread`

--- a/lib/sidekiq_simple_delay/delay_methods.rb
+++ b/lib/sidekiq_simple_delay/delay_methods.rb
@@ -46,12 +46,14 @@ module SidekiqSimpleDelay
     # @option options [Symbol] :spread_mod_method method to call to get the value to use
     #   for determining mod offset
     def simple_sidekiq_delay_spread(options = {})
-      spread_duration = Utils.extract_option(options, :spread_duration, 1.hour).to_f
-      spread_in = Utils.extract_option(options, :spread_in, 0).to_f
-      spread_at = Utils.extract_option(options, :spread_at)
-      spread_method = Utils.extract_option(options, :spread_method, :rand)
-      spread_mod_value = Utils.extract_option(options, :spread_mod_value)
-      spread_mod_method = Utils.extract_option(options, :spread_mod_method)
+      local_opts = options.dup
+
+      spread_duration = Utils.extract_option(local_opts, :spread_duration, 1.hour).to_f
+      spread_in = Utils.extract_option(local_opts, :spread_in, 0).to_f
+      spread_at = Utils.extract_option(local_opts, :spread_at)
+      spread_method = Utils.extract_option(local_opts, :spread_method, :rand)
+      spread_mod_value = Utils.extract_option(local_opts, :spread_mod_value)
+      spread_mod_method = Utils.extract_option(local_opts, :spread_mod_method)
 
       spread_duration = 0 if spread_duration < 0
       spread_in = 0 if spread_in < 0
@@ -98,7 +100,7 @@ module SidekiqSimpleDelay
           Time.now.to_f + spread
         end
 
-      Proxy.new(SimpleDelayedWorker, self, options.merge('at' => t))
+      Proxy.new(SimpleDelayedWorker, self, local_opts.merge('at' => t))
     end
 
     # Tell {DelayMethods} which delayed worker to use

--- a/spec/sidekiq_simple_delay/instance_methods_spec.rb
+++ b/spec/sidekiq_simple_delay/instance_methods_spec.rb
@@ -364,6 +364,33 @@ RSpec.describe SidekiqSimpleDelay do
 
           obj.simple_delay_spread(opts).method1
         end
+
+        it 'should enqueue two jobs' do
+          obj = ValidSimpleObject.new
+
+          rand_val_1 = 20_000
+          rand_val_2 = 15_500
+          duration = 6.hours
+
+          expect(SidekiqSimpleDelay::Utils).to receive(:random_number).and_return(rand_val_1, rand_val_2)
+          expect(SidekiqSimpleDelay::Utils).to_not receive(:random_number).with(1.hour)
+
+          opts = {
+            spread_duration: duration
+          }
+
+          proxy_opts_1 = {
+            'at' => @time_f + rand_val_1
+          }
+          stub_proxy(obj, proxy_opts_1, :method1)
+          obj.simple_delay_spread(opts).method1
+
+          proxy_opts_2 = {
+            'at' => @time_f + rand_val_2
+          }
+          stub_proxy(obj, proxy_opts_2, :method2)
+          obj.simple_delay_spread(opts).method2
+        end
       end
 
       context 'mod' do
@@ -378,6 +405,23 @@ RSpec.describe SidekiqSimpleDelay do
           opts = {
             spread_method: :mod,
             spread_mod_value: 12_345
+          }
+
+          obj.simple_delay_spread(opts).method1
+        end
+
+        it 'should enqueue a job based on mod_value and spread_duration' do
+          obj = ValidSimpleObject.new
+
+          proxy_opts = {
+            'at' => @time_f + 345.0
+          }
+          stub_proxy(obj, proxy_opts, :method1)
+
+          opts = {
+            spread_method: :mod,
+            spread_mod_value: 12_345,
+            spread_duration: 10.minutes
           }
 
           obj.simple_delay_spread(opts).method1

--- a/spec/sidekiq_simple_delay/instance_methods_spec.rb
+++ b/spec/sidekiq_simple_delay/instance_methods_spec.rb
@@ -368,27 +368,27 @@ RSpec.describe SidekiqSimpleDelay do
         it 'should enqueue two jobs' do
           obj = ValidSimpleObject.new
 
-          rand_val_1 = 20_000
-          rand_val_2 = 15_500
+          rand_val1 = 20_000
+          rand_val2 = 15_500
           duration = 6.hours
 
-          expect(SidekiqSimpleDelay::Utils).to receive(:random_number).and_return(rand_val_1, rand_val_2)
+          expect(SidekiqSimpleDelay::Utils).to receive(:random_number).and_return(rand_val1, rand_val2)
           expect(SidekiqSimpleDelay::Utils).to_not receive(:random_number).with(1.hour)
 
           opts = {
             spread_duration: duration
           }
 
-          proxy_opts_1 = {
-            'at' => @time_f + rand_val_1
+          proxy_opts1 = {
+            'at' => @time_f + rand_val1
           }
-          stub_proxy(obj, proxy_opts_1, :method1)
+          stub_proxy(obj, proxy_opts1, :method1)
           obj.simple_delay_spread(opts).method1
 
-          proxy_opts_2 = {
-            'at' => @time_f + rand_val_2
+          proxy_opts2 = {
+            'at' => @time_f + rand_val2
           }
-          stub_proxy(obj, proxy_opts_2, :method2)
+          stub_proxy(obj, proxy_opts2, :method2)
           obj.simple_delay_spread(opts).method2
         end
       end


### PR DESCRIPTION
Caused issues when using the same options hash for multiple delayed jobs